### PR TITLE
Update assets/snippets/evogallery/classes/gallery.class.inc.php

### DIFF
--- a/assets/snippets/evogallery/classes/gallery.class.inc.php
+++ b/assets/snippets/evogallery/classes/gallery.class.inc.php
@@ -242,6 +242,7 @@ class Gallery
 				$item_phx->setPHxVariable('images_dir', $this->config['galleriesUrl'] . $row['content_id'] . '/');
 				$item_phx->setPHxVariable('thumbs_dir', $this->config['galleriesUrl'] . $row['content_id'] . '/thumbs/');
 				$item_phx->setPHxVariable('original_dir', $this->config['galleriesUrl'] . $row['content_id'] . '/original/');
+				$item_phx->setPHxVariable('original_dir_all', $this->config['galleriesUrl'] . $row['content_id'] . '/original/' . $row['filename']);
 				$item_phx->setPHxVariable('plugin_dir', $this->config['snippetUrl'] . $this->config['type'] . '/');
 				if(!empty($item_tpl_first) && $count == 1){
     				$items .= $item_phx->Parse($item_tpl_first);


### PR DESCRIPTION
Add new placeholder [+original_dir_all+].

Which takes a big flaxebility, for example I can use phx modifier phpthumbof in evogallery templates.

So I can use many sizes of images without change settings [+original_dir_all:phpthumbof=`w=86&h=66&zc=1`+]

I think it`s comfortabl ;)
